### PR TITLE
Fix typos etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stimulus and Webpack Tools for Django
 
-Make the usage of stimulus and webpack in Django fun (again)! 
+Make the usage of stimulus and webpack in Django fun (again)!
 
 ## Introduction
 
@@ -23,10 +23,10 @@ and add it as `apps.demo` in your settings.
 
 ### Installation
 
-Next, install the `webpack-tools` module in your python runtime, e.g. using 
+Next, install the `webpack-tools` module in your python runtime, e.g. using
 
 ```
-pip install webpack-tools 
+pip install webpack-tools
 ```
 
 or via your `requirements.txt`.
@@ -73,10 +73,10 @@ You can give zero or more controllers to be created. Those should be named all l
 
 The plugin will then
 
-* Create a folder `/javascript` in your app root folder (if it doesnt already exist).
-* Create an `application.js` with sensible defaults (auto detection of controllers during webpack execution) if it doesnt exist.
-* Create a subfolder `/controllers` (if it doestn exist)
-* Create a stub for each controller named `{controller}_controller.js` (the default convention, in stimulus).
+* Create a folder `/javascript` in your app root folder (if it doesn't already exist).
+* Create an `application.js` with sensible defaults (auto detection of controllers during webpack execution) if it doesn't exist.
+* Create a subfolder `/controllers` (if it doesn't exist)
+* Create a stub for each controller named `{controller}_controller.js` (the default convention in stimulus).
 
 Optionally, you can also create one (or more) view template which has the proper setup to get started even quicker.
 For that, just append `--templates {template1} .. {templateN}` to the command above, i.e.
@@ -89,8 +89,7 @@ This will then create the respective templates in your apps `/template` folder a
 
 ## Bundling with webpack
 
-Now its the right time to come back to `webpack`s `--bundle` command.
-So just execute
+Now it's the right time to come back to `webpack`s `--bundle` command.
 
 ```
 python manage.py webpack --bundle
@@ -113,13 +112,12 @@ There are two approaches. One is that the other modules provide npm packages and
 
 The `install_controller` helps you in the second case and does all necessary changes in your `application.js` file.
 If one app defines a Controller (from the structure defines above) and it should be added to an entrypoint in another app, one can use the `install_controller` command.
-The Syntax is
 
 ```
 python manage.py install_controller <target-app> <source-app> <controller-name>
 ```
 
-If you have two apps `apps/demo` and `apps/demo2` and want to install athe controller `Mycontroller` from `apps/demo/javascript/controllers/mycontroller_controller.js` into `apps/demo2`s entrypoint (which is `apps/demo2/javascript/application.js`) then you have to use the command
+If you have two apps `apps/demo` and `apps/demo2` and want to install the controller `Mycontroller` from `apps/demo/javascript/controllers/mycontroller_controller.js` into `apps/demo2`s entrypoint (which is `apps/demo2/javascript/application.js`) then you have to use the command
 
 ```
 python manage.py install_controller apps.demo2 apps.demo mycontroller

--- a/webpack_tools/management/commands/stimulus.py
+++ b/webpack_tools/management/commands/stimulus.py
@@ -3,7 +3,6 @@ import os
 from importlib import import_module
 
 from django.core.management.base import BaseCommand, CommandError
-from django.core.management.templates import TemplateCommand
 from django.template.loader import render_to_string
 
 

--- a/webpack_tools/management/commands/webpack.py
+++ b/webpack_tools/management/commands/webpack.py
@@ -1,7 +1,7 @@
 import subprocess
 import os
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.template.loader import render_to_string
 
 
@@ -57,13 +57,13 @@ class Command(BaseCommand):
 
     def npm_init(self, *args, **options):
         if os.path.exists('package.json'):
-            self.stdout.write(self.style.ERROR('Existing package.json already found, dont initialising npm!'))
+            self.stdout.write(self.style.ERROR('Existing package.json already found, skipping initialising package.json!'))
             return
         response = subprocess.run(["npm", "init", "-y"])
         if response.returncode == 0:
             self.stdout.write(self.style.SUCCESS('package.json was created sucessfully!'))
         else:
-            self.stdout.write(self.style.WARNING('Unnable to init npm, see above for more details!'))
+            self.stdout.write(self.style.WARNING('Unable to init npm, see above for more details!'))
 
     def npm_install_dev_dependencies(self, *args, **options):
         if not os.path.exists('package.json'):

--- a/webpack_tools/templates/webpack_tools/application.js
+++ b/webpack_tools/templates/webpack_tools/application.js
@@ -4,7 +4,7 @@ import { definitionsFromContext } from "stimulus/webpack-helpers"
 // DO NOT REMOVE THIS AND THE FOLLOWING LINE
 // Custom Controller Imports
 
-// This file automatically initialised by stimulus-webpack-helper
+// This file is automatically initialised by stimulus-webpack-helper
 const application = Application.start()
 const context = require.context("./controllers", true, /\.js$/)
 application.load(definitionsFromContext(context))


### PR DESCRIPTION
I had a readthrough of the repo. All in all I think it looks good, you do some clever things. 

Some improvements that could possibly be made is to have settings for two things. 

- the javascript folder; in case they somehow want to name it differently; not super important as I think `javascript` is a pretty reasonable name. 
- be able to use yarn instead of npm. It's basically a drop-in replacement. 


> Those will be bundled in a single `application.js` file which will be copied to `static/js/application.js`

If I've got several django apps, will it work correctly? I assume that the stimulus command will create several `application.js` if you do it for several django apps. I haven't tried, but when reading through the code that's what I asked myself. 

Have a watch command. 
